### PR TITLE
Include spaces in stroke count

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 var _ = require('underscore');
+var jsmin = require('jsmin').jsmin;
 
 var game;
 var savePath = __dirname + '/data/game.json';
@@ -48,7 +49,7 @@ var addEntry = function(data) {
 
   var countStrokes = function(file) {
     if (fs.existsSync(file)) {
-      var contents = fs.readFileSync(file, 'utf8').replace(/\s/g, '');
+      var contents = jsmin(fs.readFileSync(file, 'utf8'));
       return contents.length;
     }
   };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "express": "~3.4.0",
     "mustachex": "0.0.2",
-    "underscore": "~1.5.2"
+    "underscore": "~1.5.2",
+    "jsmin": "~1.0.1"
   }
 }


### PR DESCRIPTION
They entry is tested with spaces and so there is no guarantee the entry works/is actually valid without spaces.

Sorry if I missed some other reason for this?

There is also a shout for reading up to the play function definition and only include the body in the count, this would impose a restriction on the format that could be submitted (not a huge issue)
