### PR TITLE
Strip preceeding newlines

### DIFF
--- a/game/game.js
+++ b/game/game.js
@@ -49,7 +49,7 @@ var addEntry = function(data) {
 
   var countStrokes = function(file) {
     if (fs.existsSync(file)) {
-      var contents = jsmin(fs.readFileSync(file, 'utf8'), 3);
+      var contents = jsmin(fs.readFileSync(file, 'utf8'), 3).replace(/^\n+/, '');
       return contents.length;
     }
   };


### PR DESCRIPTION
For some reason, if there is at least one newline before the start of the actual code, jsmin will always be preserve one newline.

This behaviour has been "corrected"

Here's a test that proves it:

``` js
console.dir(require('jsmin').jsmin('\nvar hello = function(){\n  return true;\n}\n'))
```
